### PR TITLE
fixes some browserify bugs I was running into.

### DIFF
--- a/lib/ava-bundler.js
+++ b/lib/ava-bundler.js
@@ -4,11 +4,14 @@ var resolveFrom = require('resolve-from');
 var replaceTransform = require('./replace-transform');
 
 module.exports = function (cwd, debug, browserAdapterPath) {
-	var avaBundler = browserify({debug: debug, basedir: cwd});
+	var avaBundler = browserify({debug: debug, basedir: cwd, fullPaths: true});
 	var processAdapterPath = resolveFrom(cwd, 'ava/lib/process-adapter');
+	var avaPath = resolveFrom(cwd, 'ava');
+	avaBundler.avaProcessAdapterPath = processAdapterPath;
 
-	avaBundler.require('ava/lib/process-adapter', {expose: 'ava/lib/process-adapter'});
-	avaBundler.require('ava');
+	avaBundler.require(processAdapterPath);
+
+	avaBundler.require(avaPath);
 
 	avaBundler.transform(replaceTransform(processAdapterPath, browserAdapterPath), {global: true});
 

--- a/lib/ava-bundler.js
+++ b/lib/ava-bundler.js
@@ -1,0 +1,16 @@
+'use strict';
+var browserify = require('browserify');
+var resolveFrom = require('resolve-from');
+var replaceTransform = require('./replace-transform');
+
+module.exports = function (cwd, debug, browserAdapterPath) {
+	var avaBundler = browserify({debug: debug, basedir: cwd});
+	var processAdapterPath = resolveFrom(cwd, 'ava/lib/process-adapter');
+
+	avaBundler.require('ava/lib/process-adapter', {expose: 'ava/lib/process-adapter'});
+	avaBundler.require('ava');
+
+	avaBundler.transform(replaceTransform(processAdapterPath, browserAdapterPath), {global: true});
+
+	return avaBundler;
+};

--- a/lib/child-process-middleware.js
+++ b/lib/child-process-middleware.js
@@ -8,9 +8,6 @@ function middleware(req, res) {
 		'  <body>',
 		'    <script src="/karma-ava/' + req.params.hash1 + '.js"></script>',
 		'    <script src="/karma-ava/' + req.params.hash2 + '.js"></script>',
-		'    <script>',
-		'      require("ava/lib/process-adapter");',
-		'    </script>',
 		'  </body>',
 		'<html>'
 	].join('\n'));

--- a/lib/externalize-bundle.js
+++ b/lib/externalize-bundle.js
@@ -1,37 +1,32 @@
 'use strict';
-var through = require('through2');
-var objectAssign = require('object-assign');
+var builtins = require('browserify/lib/builtins');
+var browserResolve = require('browser-resolve');
 
 // Adapted from browserify.prototype.external.
 // This could be made much simpler with some help from browserify.
 // See: https://github.com/substack/node-browserify/pull/1577
 module.exports = function (bundler) {
 	var externalIds = [];
-	var bdeps = {};
-	var blabels = {};
 
 	bundler.on('label', function (prev, id) {
 		externalIds.push(prev);
+
 		if (prev !== id) {
-			blabels[prev] = id;
 			externalIds.push(id);
 		}
 	});
 
-	bundler.pipeline.get('deps').push(through.obj(function (row, enc, next) {
-		bdeps = objectAssign(bdeps, row.deps);
-		this.push(row);
-		next();
-	}));
-
 	function rewriteIndex(row) {
 		Object.keys(row.deps).forEach(function (key) {
-			var prev = bdeps[key];
-			if (prev) {
-				var id = blabels[prev];
-				if (id) {
-					row.indexDeps[key] = id;
-				}
+			var resolved = browserResolve.sync(key, {
+				filename: row.file,
+				modules: builtins
+			});
+
+			row.deps[key] = resolved;
+
+			if (row.indexDeps) {
+				row.indexDeps[key] = resolved;
 			}
 		});
 	}

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -32,6 +32,7 @@ function preprocessorFactory(cwd, bundler) {
 
 		ava.then(function (avaHash) {
 			bundler.bundleFile(file.originalPath, content)
+				.then(bundler.appendRequire)
 				.then(hashAndCache)
 				.then(function (fileHash) {
 					return 'window.__AVA__.addFile("' + avaHash + '", "' + fileHash + '", "' + prefix + '");\n';

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -35,9 +35,13 @@ function preprocessorFactory(cwd, bundler) {
 				.then(bundler.appendRequire)
 				.then(hashAndCache)
 				.then(function (fileHash) {
-					return 'window.__AVA__.addFile("' + avaHash + '", "' + fileHash + '", "' + prefix + '");\n';
+					done(null, 'window.__AVA__.addFile("' + avaHash + '", "' + fileHash + '", "' + prefix + '");\n');
 				})
-				.nodeify(done);
+				.catch(function (err) {
+					// TODO: Should fail the build
+					console.log(err);
+					done(null, ' ');
+				});
 		});
 	};
 }

--- a/lib/replace-transform.js
+++ b/lib/replace-transform.js
@@ -2,6 +2,7 @@
 var fs = require('fs');
 var stream = require('stream');
 var pify = require('pify');
+var Promise = require('bluebird');
 
 // Replace the contents of one file with another.
 // Like the browserify `browser` in package.json field, but can be used to replace things inside `node_modules`.
@@ -13,7 +14,7 @@ module.exports = function (from, to) {
 		}
 
 		var transform = new stream.Transform();
-		var replacement = pify(fs).readFile(to, 'utf8');
+		var replacement = pify(fs, Promise).readFile(to, 'utf8');
 
 		transform._transform = function (buf, enc, cb) {
 			// ignore incoming file

--- a/lib/test-bundler.js
+++ b/lib/test-bundler.js
@@ -1,36 +1,20 @@
 'use strict';
 var path = require('path');
 var browserify = require('browserify');
-var resolveFrom = require('resolve-from');
 var externalizeBundle = require('./externalize-bundle');
 var getBundlePromise = require('./promisify-bundle');
 var babelTransform = require('./babel-transform');
-var replaceTransform = require('./replace-transform');
+var makeAvaBundler = require('./ava-bundler');
 
 function bundlerFactory(cwd) {
-	var avaBundler = browserify({debug: true, basedir: cwd});
-	var processAdapterPath = resolveFrom(cwd, 'ava/lib/process-adapter');
 	var browserAdapterPath = path.join(__dirname, 'browser-adapter.js');
-
-	[
-		'ava/lib/process-adapter',
-		'ava/lib/globals',
-		'ava/lib/test-worker',
-		'ava'
-	].forEach(function (val) {
-		var isArray = Array.isArray(val);
-		var id = isArray ? val[0] : val;
-		var expose = isArray ? val[1] : val;
-		avaBundler.require(id, {expose: expose, basedir: cwd});
-	});
-
-	avaBundler.transform(replaceTransform(processAdapterPath, browserAdapterPath), {global: true});
+	var avaBundler = makeAvaBundler(cwd, true, browserAdapterPath);
 
 	var externalizeAva = externalizeBundle(avaBundler);
-	var ava = getBundlePromise(avaBundler);
+	var avaP = getBundlePromise(avaBundler);
 
 	function bundleFile(file, src) {
-		return ava.then(function () {
+		return avaP.then(function () {
 			var fileCache = {};
 
 			if (src) {
@@ -53,7 +37,7 @@ function bundlerFactory(cwd) {
 	}
 
 	return {
-		ava: ava,
+		ava: avaP,
 		bundleFile: bundleFile
 	};
 }

--- a/lib/test-bundler.js
+++ b/lib/test-bundler.js
@@ -21,7 +21,7 @@ function bundlerFactory(cwd) {
 				fileCache[file] = src;
 			}
 
-			var bundler = browserify({debug: true, basedir: cwd, fileCache: fileCache});
+			var bundler = browserify({debug: true, basedir: cwd, fileCache: fileCache, fullPaths: true});
 
 			bundler.transform(babelTransform({
 				cwd: cwd,
@@ -36,9 +36,17 @@ function bundlerFactory(cwd) {
 		});
 	}
 
+	var requireCode = ';\nrequire("' + avaBundler.avaProcessAdapterPath + '");';
+
+	function appendRequire(code) {
+		return code + requireCode;
+	}
+
 	return {
 		ava: avaP,
-		bundleFile: bundleFile
+		bundleFile: bundleFile,
+		requireCode: requireCode,
+		appendRequire: appendRequire
 	};
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "babel-core": "^6.9.1",
     "bluebird": "^3.4.1",
+    "browser-resolve": "^1.11.2",
     "browserify": "^13.0.1",
     "express": "^4.14.0",
     "figures": "^1.7.0",

--- a/test/babel-transform.js
+++ b/test/babel-transform.js
@@ -9,7 +9,7 @@ test('successfully converts es2015 code', async () => {
 	b.transform(babelTransform({file: fixture('test', 'es2015.js')}));
 	b.external('ava-bundler-external/process-adapter');
 	b.add(fixture('test', 'es2015.js'));
-	await pify(b.bundle.bind(b))();
+	await pify(b.bundle.bind(b), Promise)();
 });
 
 test('dows not convert if file does not match', t => {
@@ -17,5 +17,5 @@ test('dows not convert if file does not match', t => {
 	b.transform(babelTransform({file: fixture('test', 'es2015.js')}));
 	b.external('ava-bundler-external/process-adapter');
 	b.add(fixture('test', '_es2015.js'));
-	t.throws(pify(b.bundle.bind(b))());
+	t.throws(pify(b.bundle.bind(b), Promise)());
 });

--- a/test/cache-middleware.js
+++ b/test/cache-middleware.js
@@ -5,7 +5,8 @@ import findCacheDir from 'find-cache-dir';
 import pify from 'pify';
 import cacheMiddleware from '../lib/cache-middleware';
 
-const fsP = pify(fs);
+const fsP = pify(fs, Promise);
+
 const time = () => process.hrtime().join('-');
 
 async function macro(t, name) {


### PR DESCRIPTION
Closes #1, but not as cleanly as I had hoped.

Instead of browserifies `external` method (or the previously extracted version), I wrote a simplified version. It requires that both bundles (the common bundle, and the bundle using it as an external) use the `fullPaths` option in browserify. This results in a slightly larger bundle, but that's not really a big deal in this case (these files aren't for deployment).

Of greater concern is the use of `browserResolve.sync(..)`. That resolution is almost certainly already happening once - so doing this likely creates a performance hit. Perhaps we can make a PR to browserify to expose resolved paths and avoid doing this lookup again.
